### PR TITLE
Re-export indexmap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,3 +115,4 @@ pub mod protocol;
 pub mod records;
 
 pub use error::ResponseError;
+pub use indexmap;


### PR DESCRIPTION
Indexmap is a dependency of this crate which is required in order to build many of the message types of this crate, making it part of the public API. As such, we re-export the crate so that users have immediate access to the code they need in order to use this crate meaningfully.